### PR TITLE
move couch2pg from stop -> assess

### DIFF
--- a/radar/2024-04-17/couch2pg.md
+++ b/radar/2024-04-17/couch2pg.md
@@ -1,0 +1,10 @@
+---
+title:      "couch2pg"
+ring:       stop
+quadrant:   tools
+tags:       [data]
+---
+
+[couch2pg](https://github.com/medic/couch2pg) is library and cli for one-way replicating CouchDB databases to PostgreSQL 9.4+.
+
+It is currently in maintenance. Look into [cht-sync](https://github.com/medic/cht-sync) and [cht-pipeline](https://github.com/medic/cht-pipeline) instead.

--- a/radar/2024-06-03/couch2pg.md
+++ b/radar/2024-06-03/couch2pg.md
@@ -1,0 +1,10 @@
+---
+title:      "couch2pg"
+ring:       assess
+quadrant:   tools
+tags:       [data]
+---
+
+[couch2pg](https://github.com/medic/couch2pg) is library and cli for one-way replicating CouchDB databases to PostgreSQL 9.4+.
+
+It is currently being revived to compliment the recent re-archecture of [cht-sync](https://github.com/medic/cht-sync) and [cht-pipeline](https://github.com/medic/cht-pipeline).


### PR DESCRIPTION
Not quite sure if we're ready for this or if this is the right content, but noted it shouldn't be in `stop` anymore given it's actively being revived.