### PR TITLE
chore: update continuous discovery

### DIFF
--- a/radar/2023-09-12/continuous-discovery.md
+++ b/radar/2023-09-12/continuous-discovery.md
@@ -5,4 +5,4 @@ quadrant:   methods-and-patterns
 tags:       [product-development]
 ---
 
-Continuous Discovery is a product development process used by Medic to build new functionalities to the CHT.
+Continuous Discovery is a product development process used by Medic to build new functionalities for the CHT.

--- a/radar/2023-09-12/continuous-discovery.md
+++ b/radar/2023-09-12/continuous-discovery.md
@@ -5,4 +5,4 @@ quadrant:   methods-and-patterns
 tags:       [product-development]
 ---
 
-[Continuous Discovery](https://docs.communityhealthtoolkit.org/contribute/medic/product-development-process/continuous-discovery-overview/) is the product development process used to build the CHT.
+Continuous Discovery is a product development process used by Medic to build new functionalities to the CHT.

--- a/radar/2024-12-06/continuous-discovery.md
+++ b/radar/2024-12-06/continuous-discovery.md
@@ -1,0 +1,8 @@
+---
+title:      "Continuous Discovery"
+ring:       stop
+quadrant:   methods-and-patterns
+tags:       [product-development]
+---
+
+In line with a community-first strategy, other product development precesses will be explored by the community. Medic stopped continuous discovery activities and team structures. 


### PR DESCRIPTION
In line with the community-first strategy, move `Continuous Discovery` product development to `Stop`.